### PR TITLE
Case sensitive route correction

### DIFF
--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -1,5 +1,5 @@
 studit_h5p.ajax:
-  resource: "@StuditH5PBundle/Controller/H5PAjaxController.php"
+  resource: "@StuditH5PBundle/Controller/H5PAJAXController.php"
   type:     annotation
 
 studit_h5p.interaction:


### PR DESCRIPTION
preventing crash of the route "studit_h5p.ajax" on case sensitive file system like linux