### PR TITLE
#1 Add return 0 for all commands

### DIFF
--- a/Command/H5pBundleCleanUpFilesCommand.php
+++ b/Command/H5pBundleCleanUpFilesCommand.php
@@ -22,7 +22,9 @@ class H5pBundleCleanUpFilesCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->cleanupFiles($input);
+	$this->cleanupFiles($input);
+
+        return 0;
     }
 
     private function cleanupFiles(InputInterface $input)

--- a/Command/H5pBundleCleanUpFilesCommand.php
+++ b/Command/H5pBundleCleanUpFilesCommand.php
@@ -24,7 +24,7 @@ class H5pBundleCleanUpFilesCommand extends Command
     {
 	$this->cleanupFiles($input);
 
-        return 0;
+	return 0;
     }
 
     private function cleanupFiles(InputInterface $input)

--- a/Command/H5pBundleIncludeAssetsCommand.php
+++ b/Command/H5pBundleIncludeAssetsCommand.php
@@ -31,7 +31,9 @@ class H5pBundleIncludeAssetsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->includeAssets();
+	$this->includeAssets();
+
+	return 0;
     }
 
     private function includeAssets()


### PR DESCRIPTION
Description
---
Symfony5 compatibility issue for commands
add `return 0;` to avoid exception in Symfony5

Test
---
Run these commands in symfony5 should work