### PR TITLE
Avoid using __toString in repositories findByXX

### DIFF
--- a/Controller/H5PInteractionController.php
+++ b/Controller/H5PInteractionController.php
@@ -86,7 +86,7 @@ class H5PInteractionController extends AbstractController{
                         'subContentId' => $subContentId,
                         'mainContent' => $contentId,
                         'dataId' => $dataType,
-                        'user' => $user
+                        'user' => $user->getId()
                     ]
                 );
                 if(!$update){
@@ -126,7 +126,7 @@ class H5PInteractionController extends AbstractController{
                     'subContentId' => $subContentId,
                     'mainContent' => $contentId,
                     'dataId' => $dataType,
-                    'user' => $user
+                    'user' => $user->getId()
                 ]
             );
             //decode for read the informations

--- a/Service/ResultService.php
+++ b/Service/ResultService.php
@@ -71,7 +71,7 @@ class ResultService
                     'subContentId' => $subContentId,
                     'mainContent' => $contentId,
                     'dataId' => $dataType,
-                    'user' => $user
+                    'user' => $user->getId()
                 ]
             );
         if (count($ContenUserData) > 0){


### PR DESCRIPTION
if __toString returns email/string instead of id, it throws exception
to avoid that I forced to get the id

plz review and tag it as normal .. thank you in advance :) 