### PR TITLE
Fix delete image on edit and avoid double slash & remove #tmp on saving

### DIFF
--- a/Core/H5POptions.php
+++ b/Core/H5POptions.php
@@ -99,15 +99,23 @@ class H5POptions
 
     public function getRelativeH5PPath()
     {
-        return "/". $this->getOption('storage_dir');
+        $dir = $this->getOption('storage_dir');
+
+        return $dir[0] === '/' ? $dir : '/' . $dir;
     }
 
     public function getAbsoluteH5PPathWithSlash(){
-        return $this->getAbsoluteWebPath() . '/' . $this->getOption('storage_dir') .'/';
+        $dir = $this->getOption('storage_dir');
+        $dir = $dir[0] === '/' ? $dir : '/' . $dir;
+
+        return $this->getAbsoluteWebPath() . $dir .'/';
     }
     public function getAbsoluteH5PPath()
     {
-        return $this->getAbsoluteWebPath() . '/' . $this->getOption('storage_dir');
+        $dir = $this->getOption('storage_dir');
+        $dir = $dir[0] === '/' ? $dir : '/' . $dir;
+
+        return $this->getAbsoluteWebPath() . $dir;
     }
 
     public function getAbsoluteWebPath()

--- a/Core/H5PSymfony.php
+++ b/Core/H5PSymfony.php
@@ -523,7 +523,7 @@ class H5PSymfony implements \H5PFrameworkInterface
     {
         $library = $this->manager->getRepository('StuditH5PBundle:Library')->find($contentData['library']['libraryId']);
         $content->setLibrary($library);
-        $content->setParameters($contentData['params']);
+        $content->setParameters(str_replace('#tmp','', $contentData['params']));
         $content->setDisabledFeatures($contentData['disable']);
         $content->setFilteredParameters(null);
         $this->manager->persist($content);

--- a/DependencyInjection/StuditH5PExtension.php
+++ b/DependencyInjection/StuditH5PExtension.php
@@ -25,7 +25,10 @@ class StuditH5PExtension extends Extension
         $loader->load('services.yml');
         /** @var $definition Definition **/
         $definition = $container->getDefinition("studit_h5p.core");
-        $definition->setArgument(1, $container->getParameter('kernel.project_dir') . '/' . $config['web_dir'] . '/' . $config["storage_dir"]);
+        $dir = $config["storage_dir"];
+        $dir[0] === '/' ? $dir : '/' . $dir;
+
+        $definition->setArgument(1, $container->getParameter('kernel.project_dir') . '/' . $config['web_dir'] . $dir);
         $definition->setArgument(2, '/');
         $definition->setArgument(3, 'en');
         $definition->setArgument(4, true);

--- a/Editor/LibraryStorage.php
+++ b/Editor/LibraryStorage.php
@@ -65,7 +65,7 @@ class LibraryStorage
         if (!$content){
             $contentData['id'] = $contentId;
         }
-        $this->updateLibraryFiles($contentId, $contentData, $oldLibrary, $oldParameters);
+        $this->updateLibraryFiles($contentId, $contentData, $oldLibrary, $oldParameters->params ?? null);
         return $contentId;
     }
     private function updateLibraryFiles($contentId, $contentData, $oldLibrary, $oldParameters)


### PR DESCRIPTION
3 fixes
- remove #tmp from the images on saving the content (this will help on getting the image from the content/{id} folder instead of the editor folder)
- `Editor/LibraryStorage.php:68` sent the params instead of params->params to h5p-core 
this help to delete the image from content/{id} folder 
scenario: edit any content and delete image 
result: image not deleted from the folder

- avoid double slash // on the storage_dir parameter 
scenario: add `storage_dir: /h5p` inside the config