### PR TITLE
Bugfix: Avoid exception on clear cache (database not exist)

### DIFF
--- a/Core/H5POptions.php
+++ b/Core/H5POptions.php
@@ -6,6 +6,8 @@ namespace Studit\H5PBundle\Core;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Studit\H5PBundle\Entity\Option;
+use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 
 class H5POptions
 {
@@ -41,7 +43,10 @@ class H5POptions
 
     public function getOption($name, $default = null)
     {
-        $this->retrieveStoredConfig();
+        try {
+            $this->retrieveStoredConfig();
+        } catch (ConnectionException | TableNotFoundException $e) {
+        }
 
         if (isset($this->storedConfig[$name])) {
             return $this->storedConfig[$name];


### PR DESCRIPTION
Scenario:
Given: database not created yet (or empty database)

Problem: composer install -> clear cache

Exception: ConnectionException or TableNotFoundException 

Solution: try/catch the error on the getter side