### PR TITLE
12 - avoid double insert unique constraint exception

### DIFF
--- a/Core/H5PSymfony.php
+++ b/Core/H5PSymfony.php
@@ -630,6 +630,19 @@ class H5PSymfony implements \H5PFrameworkInterface
             }
         }
         foreach ($librariesInUse as $dependency) {
+            // avoid content libraries inserted at the same time from two diff requests
+            $ContentLibraryExist = $this->manager->getRepository('StuditH5PBundle:ContentLibraries')
+                ->findOneBy([
+                    'content' => $contentId,
+                    'weight' => $dependency['weight'],
+                    'library' => $dependency['library']['libraryId'],
+                ])
+            ;
+
+            if ($ContentLibraryExist) {
+                continue;
+            }
+
             $dropCss = in_array($dependency['library']['machineName'], $dropLibraryCssList);
             $contentLibrary = new ContentLibraries();
             $contentLibrary->setContent($content);


### PR DESCRIPTION
in rare cases two requests happened at the same exact time 
and both requests call `deleteLibraryUsage` then `saveLibraryUsage`

one of the requests success and the other failed (unique constraint exception error)
to avoid that .. I added try-catch to avoid double insert the records at this case