### PR TITLE
fix: short namespace alias cause "Class X does not exist"

### DIFF
--- a/Controller/H5PController.php
+++ b/Controller/H5PController.php
@@ -37,7 +37,7 @@ class H5PController extends AbstractController
      */
     public function listAction()
     {
-        $contents = $this->getDoctrine()->getRepository('StuditH5PBundle:Content')->findAll();
+        $contents = $this->getDoctrine()->getRepository('Studit\H5PBundle\Entity\Content')->findAll();
         return $this->render('@StuditH5P/list.html.twig', ['contents' => $contents]);
     }
     /**

--- a/Controller/H5PInteractionController.php
+++ b/Controller/H5PInteractionController.php
@@ -80,7 +80,7 @@ class H5PInteractionController extends AbstractController{
                 /**
                  * @var ContentUserData $update
                  */
-                $update = $em->getRepository("StuditH5PBundle:ContentUserData")->findOneBy(
+                $update = $em->getRepository("Studit\H5PBundle\Entity\ContentUserData")->findOneBy(
                     [
                         'subContentId' => $subContentId,
                         'mainContent' => $contentId,
@@ -104,7 +104,7 @@ class H5PInteractionController extends AbstractController{
                     /**
                      * @var $content Content
                      */
-                    $content = $em->getRepository('StuditH5PBundle:Content')->findOneBy(['id' => $contentId]);
+                    $content = $em->getRepository('Studit\H5PBundle\Entity\Content')->findOneBy(['id' => $contentId]);
                     $contentUserData->setMainContent($content);
                     $em->persist($contentUserData);
                     $em->flush();
@@ -121,7 +121,7 @@ class H5PInteractionController extends AbstractController{
 
             return new JsonResponse(['success' => true]);
         }else{
-            $data = $em->getRepository("StuditH5PBundle:ContentUserData")->findOneBy(
+            $data = $em->getRepository("Studit\H5PBundle\Entity\ContentUserData")->findOneBy(
                 [
                     'subContentId' => $subContentId,
                     'mainContent' => $contentId,

--- a/Core/H5PIntegration.php
+++ b/Core/H5PIntegration.php
@@ -148,7 +148,7 @@ class H5PIntegration
             ]
         ];
         if (is_object($this->tokenStorage->getToken()->getUser())) {
-            $contentUserData = $this->entityManager->getRepository('StuditH5PBundle:ContentUserData')->findOneBy(['mainContent' => $content, 'user' => $this->tokenStorage->getToken()->getUser()->getId()]);
+            $contentUserData = $this->entityManager->getRepository('Studit\H5PBundle\Entity\ContentUserData')->findOneBy(['mainContent' => $content, 'user' => $this->tokenStorage->getToken()->getUser()->getId()]);
             if ($contentUserData) {
                 $content_user_data[$contentUserData->getSubContentId()][$contentUserData->getDataId()] = $contentUserData->getData();
             }

--- a/Core/H5POptions.php
+++ b/Core/H5POptions.php
@@ -61,7 +61,7 @@ class H5POptions
 
         if (!isset($this->storedConfig[$name]) || $this->storedConfig[$name] !== $value) {
             $this->storedConfig[$name] = $value;
-            $option = $this->manager->getRepository('StuditH5PBundle:Option')->find($name);
+            $option = $this->manager->getRepository('Studit\H5PBundle\Entity\Option')->find($name);
             if (!$option) {
                 $option = new Option($name);
             }
@@ -75,7 +75,7 @@ class H5POptions
     {
         if ($this->storedConfig === null) {
             $this->storedConfig = [];
-            $options = $this->manager->getRepository('StuditH5PBundle:Option')->findAll();
+            $options = $this->manager->getRepository('Studit\H5PBundle\Entity\Option')->findAll();
             foreach ($options as $option) {
                 $this->storedConfig[$option->getName()] = $option->getValue();
             }

--- a/Core/H5PSymfony.php
+++ b/Core/H5PSymfony.php
@@ -284,9 +284,9 @@ class H5PSymfony implements \H5PFrameworkInterface
                 'l1.preloadedJs as preloadedJs',
                 'l1.preloadedCss as preloadedCss',
             ])
-            ->from('StuditH5PBundle:Library', 'l1')
+            ->from('Studit\H5PBundle\Entity\Library', 'l1')
             ->leftJoin(
-                'StuditH5PBundle:Library',
+                'Studit\H5PBundle\Entity\Library',
                 'l2',
                 Expr\Join::WITH,
                 new Expr\Andx([
@@ -321,7 +321,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function loadLibraries()
     {
-        $res = $this->manager->getRepository('StuditH5PBundle:Library')->findBy([], ['title' => 'ASC', 'majorVersion' => 'ASC', 'minorVersion' => 'ASC']);
+        $res = $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->findBy([], ['title' => 'ASC', 'majorVersion' => 'ASC', 'minorVersion' => 'ASC']);
         $libraries = [];
         foreach ($res as $library) {
             $libraries[$library->getMachineName()][] = $library;
@@ -348,7 +348,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function getLibraryId($machineName, $majorVersion = NULL, $minorVersion = NULL)
     {
-        $library = $this->manager->getRepository('StuditH5PBundle:Library')->findOneBy(['machineName' => $machineName, 'majorVersion' => $majorVersion, 'minorVersion' => $minorVersion]);
+        $library = $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->findOneBy(['machineName' => $machineName, 'majorVersion' => $majorVersion, 'minorVersion' => $minorVersion]);
         return $library ? $library->getId() : null;
     }
 
@@ -378,7 +378,7 @@ class H5PSymfony implements \H5PFrameworkInterface
         if ($this->getOption('dev_mode', FALSE)) {
             return TRUE;
         }
-        return $this->manager->getRepository('StuditH5PBundle:Library')->isPatched($library);
+        return $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->isPatched($library);
     }
 
 
@@ -458,7 +458,7 @@ class H5PSymfony implements \H5PFrameworkInterface
                 }
             }
         } else {
-            $library = $this->manager->getRepository('StuditH5PBundle:Library')->find($libraryData['libraryId']);
+            $library = $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->find($libraryData['libraryId']);
             $library->setTitle($libraryData['title']);
             $library->setPatchVersion($libraryData['patchVersion']);
             $library->setFullscreen($libraryData['fullscreen']);
@@ -474,7 +474,7 @@ class H5PSymfony implements \H5PFrameworkInterface
             $this->manager->flush();
             $this->deleteLibraryDependencies($libraryData['libraryId']);
         }
-        $languages = $this->manager->getRepository('StuditH5PBundle:LibrariesLanguages')->findBy(['library' => $library]);
+        $languages = $this->manager->getRepository('Studit\H5PBundle\Entity\LibrariesLanguages')->findBy(['library' => $library]);
         foreach ($languages as $language) {
             $this->manager->remove($language);
         }
@@ -524,7 +524,7 @@ class H5PSymfony implements \H5PFrameworkInterface
 
     private function storeContent($contentData, Content $content)
     {
-        $library = $this->manager->getRepository('StuditH5PBundle:Library')->find($contentData['library']['libraryId']);
+        $library = $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->find($contentData['library']['libraryId']);
         $content->setLibrary($library);
         $content->setParameters(str_replace('#tmp','', $contentData['params']));
         $content->setDisabledFeatures($contentData['disable']);
@@ -540,7 +540,7 @@ class H5PSymfony implements \H5PFrameworkInterface
     public function updateContent($contentData, $contentMainId = NULL)
     {
         /** @var $content Content*/
-        $content = $this->manager->getRepository('StuditH5PBundle:Content')->find($contentData['id']);
+        $content = $this->manager->getRepository('Studit\H5PBundle\Entity\Content')->find($contentData['id']);
         return $this->storeContent($contentData, $content);
     }
 
@@ -549,7 +549,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function resetContentUserData($contentId)
     {
-        $contentUserDatas = $this->manager->getRepository('StuditH5PBundle:ContentUserData')->findBy(['mainContent' => $contentId, 'deleteOnContentChange' => true]);
+        $contentUserDatas = $this->manager->getRepository('Studit\H5PBundle\Entity\ContentUserData')->findBy(['mainContent' => $contentId, 'deleteOnContentChange' => true]);
         foreach ($contentUserDatas as $contentUserData) {
             $contentUserData->setData('RESET');
             $contentUserData->setTimestamp(time());
@@ -565,9 +565,9 @@ class H5PSymfony implements \H5PFrameworkInterface
     {
         foreach ($dependencies as $dependency) {
             /** @var Library $library*/
-            $library = $this->manager->getRepository('StuditH5PBundle:Library')->find($libraryId);
+            $library = $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->find($libraryId);
             /** @var Library $requiredLibrary*/
-            $requiredLibrary = $this->manager->getRepository('StuditH5PBundle:Library')->findOneBy(['machineName' => $dependency['machineName'], 'majorVersion' => $dependency['majorVersion'], 'minorVersion' => $dependency['minorVersion']]);
+            $requiredLibrary = $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->findOneBy(['machineName' => $dependency['machineName'], 'majorVersion' => $dependency['majorVersion'], 'minorVersion' => $dependency['minorVersion']]);
             $libraryLibraries = new LibraryLibraries();
             $libraryLibraries->setLibrary($library);
             $libraryLibraries->setRequiredLibrary($requiredLibrary);
@@ -582,8 +582,8 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function copyLibraryUsage($contentId, $copyFromId, $contentMainId = NULL)
     {
-        $contentLibrariesFrom = $this->manager->getRepository('StuditH5PBundle:ContentLibraries')->findBy(['content' => $copyFromId]);
-        $contentTo = $this->manager->getRepository('StuditH5PBundle:Content')->find($contentId);
+        $contentLibrariesFrom = $this->manager->getRepository('Studit\H5PBundle\Entity\ContentLibraries')->findBy(['content' => $copyFromId]);
+        $contentTo = $this->manager->getRepository('Studit\H5PBundle\Entity\Content')->find($contentId);
         foreach ($contentLibrariesFrom as $contentLibrary) {
             $contentLibraryTo = clone $contentLibrary;
             $contentLibraryTo->setContent($contentTo);
@@ -597,7 +597,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function deleteContentData($contentId)
     {
-        $content = $this->manager->getRepository('StuditH5PBundle:Content')->find($contentId);
+        $content = $this->manager->getRepository('Studit\H5PBundle\Entity\Content')->find($contentId);
         if ($content) {
             $this->manager->remove($content);
             $this->manager->flush();
@@ -609,7 +609,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function deleteLibraryUsage($contentId)
     {
-        $contentLibraries = $this->manager->getRepository('StuditH5PBundle:ContentLibraries')->findBy(['content' => $contentId]);
+        $contentLibraries = $this->manager->getRepository('Studit\H5PBundle\Entity\ContentLibraries')->findBy(['content' => $contentId]);
         foreach ($contentLibraries as $contentLibrary) {
             $this->manager->remove($contentLibrary);
         }
@@ -623,7 +623,7 @@ class H5PSymfony implements \H5PFrameworkInterface
     public function saveLibraryUsage($contentId, $librariesInUse)
     {
 
-        $content = $this->manager->getRepository('StuditH5PBundle:Content')->find($contentId);
+        $content = $this->manager->getRepository('Studit\H5PBundle\Entity\Content')->find($contentId);
         $dropLibraryCssList = array();
         foreach ($librariesInUse as $dependency) {
             if (!empty($dependency['library']['dropLibraryCss'])) {
@@ -634,7 +634,7 @@ class H5PSymfony implements \H5PFrameworkInterface
             $dropCss = in_array($dependency['library']['machineName'], $dropLibraryCssList);
             $contentLibrary = new ContentLibraries();
             $contentLibrary->setContent($content);
-            $library = $this->manager->getRepository('StuditH5PBundle:Library')->find($dependency['library']['libraryId']);
+            $library = $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->find($dependency['library']['libraryId']);
             $contentLibrary->setLibrary($library);
             $contentLibrary->setWeight($dependency['weight']);
             $contentLibrary->setDropCss($dropCss);
@@ -665,9 +665,9 @@ class H5PSymfony implements \H5PFrameworkInterface
         if ($skipContent) {
             $usage['content'] = -1;
         } else {
-            $usage['content'] = $this->manager->getRepository('StuditH5PBundle:Library')->countContentLibrary($libraryId);
+            $usage['content'] = $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->countContentLibrary($libraryId);
         }
-        $usage['libraries'] = $this->manager->getRepository('StuditH5PBundle:LibraryLibraries')->countLibraries($libraryId);
+        $usage['libraries'] = $this->manager->getRepository('Studit\H5PBundle\Entity\LibraryLibraries')->countLibraries($libraryId);
         return $usage;
     }
 
@@ -676,12 +676,12 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function loadLibrary($machineName, $majorVersion, $minorVersion)
     {
-        $library = $this->manager->getRepository('StuditH5PBundle:Library')->findOneArrayBy(['machineName' => $machineName, 'majorVersion' => $majorVersion, 'minorVersion' => $minorVersion]);
+        $library = $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->findOneArrayBy(['machineName' => $machineName, 'majorVersion' => $majorVersion, 'minorVersion' => $minorVersion]);
         if (!$library) {
             return false;
         }
         $library['libraryId'] = $library['id'];
-        $libraryLibraries = $this->manager->getRepository('StuditH5PBundle:LibraryLibraries')->findBy(['library' => $library['id']]);
+        $libraryLibraries = $this->manager->getRepository('Studit\H5PBundle\Entity\LibraryLibraries')->findBy(['library' => $library['id']]);
         foreach ($libraryLibraries as $dependency) {
             $requiredLibrary = $dependency->getRequiredLibrary();
             $library["{$dependency->getDependencyType()}Dependencies"][] = [
@@ -698,7 +698,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function loadLibrarySemantics($machineName, $majorVersion, $minorVersion)
     {
-        $library = $this->manager->getRepository('StuditH5PBundle:Library')->findOneBy(['machineName' => $machineName, 'majorVersion' => $majorVersion, 'minorVersion' => $minorVersion]);
+        $library = $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->findOneBy(['machineName' => $machineName, 'majorVersion' => $majorVersion, 'minorVersion' => $minorVersion]);
         if ($library) {
             return $library->getSemantics();
         }
@@ -719,7 +719,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function deleteLibraryDependencies($libraryId)
     {
-        $libraries = $this->manager->getRepository('StuditH5PBundle:LibraryLibraries')->findBy(['library' => $libraryId]);
+        $libraries = $this->manager->getRepository('Studit\H5PBundle\Entity\LibraryLibraries')->findBy(['library' => $libraryId]);
         foreach ($libraries as $library) {
             $this->manager->remove($library);
         }
@@ -746,7 +746,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function deleteLibrary($library)
     {
-        $library = $this->manager->getRepository('StuditH5PBundle:Library')->find($library);
+        $library = $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->find($library);
         $this->manager->remove($library);
         $this->manager->flush();
         // Delete files
@@ -769,7 +769,7 @@ class H5PSymfony implements \H5PFrameworkInterface
         if ($type !== NULL) {
             $query['dependencyType'] = $type;
         }
-        $contentLibraries = $this->manager->getRepository('StuditH5PBundle:ContentLibraries')->findBy($query, ['weight' => 'ASC']);
+        $contentLibraries = $this->manager->getRepository('Studit\H5PBundle\Entity\ContentLibraries')->findBy($query, ['weight' => 'ASC']);
         $dependencies = [];
         foreach ($contentLibraries as $contentLibrary) {
             /** @var Library $library */
@@ -812,7 +812,7 @@ class H5PSymfony implements \H5PFrameworkInterface
         if (!isset($fields['filtered'])) {
             return;
         }
-        $content = $this->manager->getRepository('StuditH5PBundle:Content')->find($id);
+        $content = $this->manager->getRepository('Studit\H5PBundle\Entity\Content')->find($id);
         $content->setFilteredParameters($fields['filtered']);
         $this->manager->persist($content);
         $this->manager->flush();
@@ -827,7 +827,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function clearFilteredParameters($library_id)
     {
-        $contents = $this->manager->getRepository('StuditH5PBundle:Content')->findBy(['library' => $library_id]);
+        $contents = $this->manager->getRepository('Studit\H5PBundle\Entity\Content')->findBy(['library' => $library_id]);
         foreach ($contents as $content) {
             $content->setFilteredParameters('');
             $this->manager->persist($content);
@@ -840,7 +840,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function getNumNotFiltered()
     {
-        return $this->manager->getRepository('StuditH5PBundle:Content')->countNotFiltered();
+        return $this->manager->getRepository('Studit\H5PBundle\Entity\Content')->countNotFiltered();
     }
 
     /**
@@ -848,7 +848,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function getNumContent($libraryId, $skip = NULL)
     {
-        return $this->manager->getRepository('StuditH5PBundle:Content')->countLibraryContent($libraryId);
+        return $this->manager->getRepository('Studit\H5PBundle\Entity\Content')->countLibraryContent($libraryId);
     }
 
     /**
@@ -870,7 +870,7 @@ class H5PSymfony implements \H5PFrameworkInterface
         /**
          * @var Counters $results
          */
-        $results = $this->manager->getRepository('StuditH5PBundle:Counters')->findBy(['type' => $type]);
+        $results = $this->manager->getRepository('Studit\H5PBundle\Entity\Counters')->findBy(['type' => $type]);
         // Extract results
         foreach ($results as $library) {
             $count[$library->getLibraryName() . " " . $library->getLibraryVersion()] = $library->getNum();
@@ -883,7 +883,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function getNumAuthors()
     {
-        $contents = $this->manager->getRepository('StuditH5PBundle:Content')->countContent();
+        $contents = $this->manager->getRepository('Studit\H5PBundle\Entity\Content')->countContent();
         // Return 1 if there is content and 0 if there is none
         return !$contents;
     }
@@ -915,7 +915,7 @@ class H5PSymfony implements \H5PFrameworkInterface
     public function getLibraryContentCount()
     {
         $contentCount = [];
-        $results = $this->manager->getRepository('StuditH5PBundle:Content')->libraryContentCount();
+        $results = $this->manager->getRepository('Studit\H5PBundle\Entity\Content')->libraryContentCount();
         // Format results
         foreach ($results as $library) {
             $contentCount[$library['machineName'] . " " . $library['majorVersion'] . "." . $library['minorVersion']] = $library[1];

--- a/Editor/EditorAjax.php
+++ b/Editor/EditorAjax.php
@@ -35,7 +35,7 @@ class EditorAjax implements \H5PEditorAjaxInterface
      */
     public function getLatestLibraryVersions()
     {
-        return $this->manager->getRepository('StuditH5PBundle:Library')->findLatestLibraryVersions();
+        return $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->findLatestLibraryVersions();
     }
 
 
@@ -51,11 +51,11 @@ class EditorAjax implements \H5PEditorAjaxInterface
     {
         // Get only the specified content type from cache
         if ($machineName !== NULL) {
-            $contentTypeCache = $this->manager->getRepository('StuditH5PBundle:LibrariesHubCache')->findOneBy(['machineName' => $machineName]);
+            $contentTypeCache = $this->manager->getRepository('Studit\H5PBundle\Entity\LibrariesHubCache')->findOneBy(['machineName' => $machineName]);
             return [$contentTypeCache];
         }
         // Get all cached content types
-        return $this->manager->getRepository('StuditH5PBundle:LibrariesHubCache')->findAll();
+        return $this->manager->getRepository('Studit\H5PBundle\Entity\LibrariesHubCache')->findAll();
     }
 
     /**
@@ -69,7 +69,7 @@ class EditorAjax implements \H5PEditorAjaxInterface
         $recentlyUsed = [];
         $user = $this->tokenStorage->getToken()->getUser();
         if (is_object($user)) {
-            $events = $this->manager->getRepository('StuditH5PBundle:Event')->findRecentlyUsedLibraries($user->getId());
+            $events = $this->manager->getRepository('Studit\H5PBundle\Entity\Event')->findRecentlyUsedLibraries($user->getId());
             foreach ($events as $event) {
                 $recentlyUsed[] = $event['libraryName'];
             }

--- a/Editor/EditorStorage.php
+++ b/Editor/EditorStorage.php
@@ -79,7 +79,7 @@ class EditorStorage implements \H5peditorStorage
      */
     public function getLanguage($machineName, $majorVersion, $minorVersion, $language)
     {
-        return $this->entityManager->getRepository('StuditH5PBundle:LibrariesLanguages')->findForLibrary($machineName, $majorVersion, $minorVersion, $language);
+        return $this->entityManager->getRepository('Studit\H5PBundle\Entity\LibrariesLanguages')->findForLibrary($machineName, $majorVersion, $minorVersion, $language);
     }
 
     /**
@@ -97,7 +97,7 @@ class EditorStorage implements \H5peditorStorage
      */
     public function getAvailableLanguages($machineName, $majorVersion, $minorVersion)
     {
-        return $this->entityManager->getRepository('StuditH5PBundle:LibrariesLanguages')->findForLibraryAllLanguages($machineName, $majorVersion, $minorVersion);
+        return $this->entityManager->getRepository('Studit\H5PBundle\Entity\LibrariesLanguages')->findForLibraryAllLanguages($machineName, $majorVersion, $minorVersion);
     }
 
     /**
@@ -131,7 +131,7 @@ class EditorStorage implements \H5peditorStorage
             return $this->getLibrariesWithDetails($libraries, $canCreateRestricted);
         }
         $libraries = [];
-        $librariesResult = $this->entityManager->getRepository('StuditH5PBundle:Library')->findAllRunnableWithSemantics();
+        $librariesResult = $this->entityManager->getRepository('Studit\H5PBundle\Entity\Library')->findAllRunnableWithSemantics();
         foreach ($librariesResult as $library) {
             //Decode metadata setting
             $library->metadataSettings = json_decode($library->metadataSettings);
@@ -165,7 +165,7 @@ class EditorStorage implements \H5peditorStorage
         $librariesWithDetails = [];
         foreach ($libraries as $library) {
             /** @var Library $details */
-            $details = $this->entityManager->getRepository('StuditH5PBundle:Library')->findHasSemantics($library->name, $library->majorVersion, $library->minorVersion);
+            $details = $this->entityManager->getRepository('Studit\H5PBundle\Entity\Library')->findHasSemantics($library->name, $library->majorVersion, $library->minorVersion);
             if ($details) {
                 $library->tutorialUrl = $details->getTutorialUrl();
                 $library->title = $details->getTitle();

--- a/Editor/LibraryStorage.php
+++ b/Editor/LibraryStorage.php
@@ -39,7 +39,7 @@ class LibraryStorage
     public function storeLibraryData($library, $parameters, Content $content = null)
     {
         $libraryData = Utilities::getLibraryProperties($library);
-        $libraryData['libraryId'] = $this->entityManager->getRepository('StuditH5PBundle:Library')->findIdBy($libraryData['machineName'], $libraryData['majorVersion'], $libraryData['minorVersion']);
+        $libraryData['libraryId'] = $this->entityManager->getRepository('Studit\H5PBundle\Entity\Library')->findIdBy($libraryData['machineName'], $libraryData['majorVersion'], $libraryData['minorVersion']);
         if ($content) {
             $oldLibrary = [
                 'name' => $content->getLibrary()->getMachineName(),

--- a/Entity/ContentRepository.php
+++ b/Entity/ContentRepository.php
@@ -55,7 +55,7 @@ class ContentRepository extends ServiceEntityRepository
      */
     public function findUserResult($userId, Content $content)
     {
-        $contentResultRepo = $this->getEntityManager()->getRepository('StuditH5PBundle:ContentResult');
+        $contentResultRepo = $this->getEntityManager()->getRepository('Studit\H5PBundle\Entity\ContentResult');
         $response = $contentResultRepo->createQueryBuilder('cr')
             ->where('cr.userId = :userId')
             ->andWhere('cr.content = :content')

--- a/Event/H5PEvents.php
+++ b/Event/H5PEvents.php
@@ -72,7 +72,7 @@ class H5PEvents extends \H5PEventBase
         /**
          * @var Counters $current_num
         */
-        /*$current_num = $this->em->getRepository("StuditH5PBundle:Counters")->findOneBy(['type' => $type, 'libraryName' => $this->library_name, 'libraryVersion' => $this->library_version]);
+        /*$current_num = $this->em->getRepository("Studit\H5PBundle\Entity\Counters")->findOneBy(['type' => $type, 'libraryName' => $this->library_name, 'libraryVersion' => $this->library_version]);
         if(!$current_num){
             $current_num = new Counters();
             $current_num->setNum(1);

--- a/Service/ResultService.php
+++ b/Service/ResultService.php
@@ -35,8 +35,8 @@ class ResultService
             \H5PCore::ajaxError('Invalid content');
         }
         // TODO: Fire 'h5p_alter_user_result' event here.
-        $contentRepo = $this->em->getRepository('StuditH5PBundle:Content');
-        $contentResultRepo = $this->em->getRepository('StuditH5PBundle:ContentResult');
+        $contentRepo = $this->em->getRepository('Studit\H5PBundle\Entity\Content');
+        $contentResultRepo = $this->em->getRepository('Studit\H5PBundle\Entity\ContentResult');
         $result = $contentResultRepo->findOneBy(['userId' => $userId, 'content' => $contentId]);
         if (!$result) {
             $result = new ContentResult($userId);
@@ -59,7 +59,7 @@ class ResultService
      */
     public function removeData($contentId, $dataType, $user, $subContentId)
     {
-        $ContentUserData = $this->em->getRepository('StuditH5PBundle:ContentUserData')
+        $ContentUserData = $this->em->getRepository('Studit\H5PBundle\Entity\ContentUserData')
             ->findBy(
                 [
                     'subContentId' => $subContentId,


### PR DESCRIPTION
Your bundle requires doctrine/orm: ^2.7.
But from  doctrine/orm:2.12, doctrine/orm requires doctrine/persistence: ^2.4 || ^3.
And from doctrine/persistence:2.3, short namespace alias (like StuditH5PBundle:Content) are deprecated.