### PR TITLE
fix: Remove usage of depracted function getMasterRequest

### DIFF
--- a/Core/H5PIntegration.php
+++ b/Core/H5PIntegration.php
@@ -103,7 +103,7 @@ class H5PIntegration
                 'H5P' => $this->core->getLocalization(),
             ),
             'hubIsEnabled' => $hubIsEnabled,
-            'siteUrl' => $this->requestStack->getMasterRequest()->getUri(),
+            'siteUrl' => $this->requestStack->getMainRequest()->getUri(),
             'librairyConfig' => $this->core->h5pF->getLibraryConfig()
         );
         if (is_object($user)) {


### PR DESCRIPTION
getMasterRequest is depracted since SF 5.3 and was removed in SF 6, which causes errors.