### PR TITLE
fix: symfony 6 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: php-actions/composer@v6
+      - uses: php-actions/phpstan@v3
+        with:
+          memory_limit: -1

--- a/Command/H5pBundleCleanUpFilesCommand.php
+++ b/Command/H5pBundleCleanUpFilesCommand.php
@@ -2,15 +2,26 @@
 
 namespace Studit\H5PBundle\Command;
 
+use Studit\H5PBundle\Core\H5POptions;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 class H5pBundleCleanUpFilesCommand extends Command
 {
+
+    /**
+     * @var H5POptions $h5POptions
+     */
+    private $h5POptions;
+
+    public function __construct(H5POptions $h5POptions)
+    {
+        $this->h5POptions = $h5POptions;
+        parent::__construct();
+    }
+
     protected static $defaultName = 'h5p-bundle:cleanup-files';
     protected function configure()
     {
@@ -31,7 +42,7 @@ class H5pBundleCleanUpFilesCommand extends Command
     {
         $location = $input->getArgument('location');
         if (!$location) {
-            $location = $this->get('studit_h5p.options')->getAbsoluteH5PPath() . '/editor';
+            $location = $this->h5POptions->getAbsoluteH5PPath() . '/editor';
         }
         \H5PCore::deleteFileTree($location);
     }

--- a/Controller/H5PAJAXController.php
+++ b/Controller/H5PAJAXController.php
@@ -94,11 +94,9 @@ class H5PAJAXController extends AbstractController
     /**
      * Callback Install library from external file
      *
-     * @param string $token Security token
-     * @param int $content_id Id of content
-     * @param string $machine_name Machine name of library
      * @param Request $request
      *
+     * @return JsonResponse
      * @Route("/library-install/")
      */
     public function libraryInstallCallback(Request $request)
@@ -121,11 +119,8 @@ class H5PAJAXController extends AbstractController
     /**
      * Callback that returns data for a given library
      *
-     * @param string $machine_name Machine name of library
-     * @param int $major_version Major version of library
-     * @param int $minor_version Minor version of library
-     * @param string $locale Language of your website and plugins  for default is English (EN)
      * @param Request $request
+     * @return JsonResponse
      */
     private function libraryCallback(Request $request)
     {
@@ -140,7 +135,7 @@ class H5PAJAXController extends AbstractController
             $request->get('majorVersion'),
             $request->get('minorVersion'),
             $locale,
-            $this->get('studit_h5p.options')->getOption('storage_dir'),
+            $this->serviceh5poptions->getOption('storage_dir'),
             '',
             $locale
         );
@@ -158,10 +153,9 @@ class H5PAJAXController extends AbstractController
     /**
      * Callback for uploading a library
      *
-     * @param string $token Editor security token
-     * @param int $content_id Id of content that is being edited
      * @param Request $request
      *
+     * @return JsonResponse
      * @throws Exception
      * @Route("/library-upload/")
      */
@@ -194,9 +188,8 @@ class H5PAJAXController extends AbstractController
     /**
      * Callback for file uploads.
      *
-     * @param string $token SecuritlibraryCallbacky token
-     * @param int $content_id Content id
      * @param Request $request
+     * @return JsonResponse
      * @Route("/files/")
      */
     public function filesCallback(Request $request)
@@ -220,9 +213,8 @@ class H5PAJAXController extends AbstractController
     /**
      * Callback for filtering.
      *
-     * @param string $token Security token
-     * @param int $content_id Content id
      * @param Request $request
+     * @return JsonResponse
      * @Route("/filter/")
      */
     public function filterCallback(Request $request)

--- a/Controller/H5PController.php
+++ b/Controller/H5PController.php
@@ -3,6 +3,7 @@
 
 namespace Studit\H5PBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Studit\H5PBundle\Core\H5POptions;
 use Studit\H5PBundle\Editor\LibraryStorage;
 use Studit\H5PBundle\Entity\Content;
@@ -22,13 +23,16 @@ class H5PController extends AbstractController
 
     protected $h5PIntegrations;
     protected $libraryStorage;
+    protected $entityManager;
 
     public function __construct(
         H5PIntegration $h5PIntegration,
-        LibraryStorage $libraryStorage
+        LibraryStorage $libraryStorage,
+        EntityManagerInterface $entityManager
     ) {
         $this->h5PIntegrations = $h5PIntegration;
         $this->libraryStorage = $libraryStorage;
+        $this->entityManager = $entityManager;
     }
 
     /**
@@ -37,7 +41,7 @@ class H5PController extends AbstractController
      */
     public function listAction()
     {
-        $contents = $this->getDoctrine()->getRepository('Studit\H5PBundle\Entity\Content')->findAll();
+        $contents = $this->entityManager->getRepository('Studit\H5PBundle\Entity\Content')->findAll();
         return $this->render('@StuditH5P/list.html.twig', ['contents' => $contents]);
     }
     /**
@@ -78,11 +82,12 @@ class H5PController extends AbstractController
     {
         return $this->handleRequest($request );
     }
+
     /**
      * @Route("edit/{content}")
      * @param Request $request
      * @param Content $content
-     * @return
+     * @return RedirectResponse|Response
      */
     public function editAction(Request $request, Content $content)
     {

--- a/Core/H5PIntegration.php
+++ b/Core/H5PIntegration.php
@@ -5,13 +5,15 @@ namespace Studit\H5PBundle\Core;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use H5PCore;
+use H5peditor;
 use Studit\H5PBundle\Entity\Content;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-
+use Symfony\Component\Security\Core\User\UserInterface;
 
 
 class H5PIntegration
@@ -108,8 +110,8 @@ class H5PIntegration
         );
         if (is_object($user)) {
             $settings['user'] = [
-                'name' => $user->getUsername(),
-                'mail' => $user->getEmail(),
+                'name' => method_exists($user, 'getUsername') ? $user->getUsername() : $user->getUserIdentifier(),
+                'mail' => method_exists($user, 'getEmail') ? $user->getEmail() : $user->getUserIdentifier().'@'.$_SERVER['HTTP_HOST'],
             ];
         }
         return $settings;
@@ -117,10 +119,10 @@ class H5PIntegration
     /**
      * Get a list with prepared asset links that is used when JS loads components.
      *
-     * @param array [$keys] Optional keys, first for JS second for CSS.
+     * @param null|array $keys [$keys] Optional keys, first for JS second for CSS.
      * @return array
      */
-    public function getCoreAssets($keys = NULL)
+    public function getCoreAssets($keys = null)
     {
         if (empty($keys)) {
             $keys = ['scripts', 'styles'];
@@ -148,7 +150,7 @@ class H5PIntegration
             ]
         ];
         if (is_object($this->tokenStorage->getToken()->getUser())) {
-            $contentUserData = $this->entityManager->getRepository('Studit\H5PBundle\Entity\ContentUserData')->findOneBy(['mainContent' => $content, 'user' => $this->tokenStorage->getToken()->getUser()->getId()]);
+            $contentUserData = $this->entityManager->getRepository('Studit\H5PBundle\Entity\ContentUserData')->findOneBy(['mainContent' => $content, 'user' => $this->getUserId($this->tokenStorage->getToken()->getUser())]);
             if ($contentUserData) {
                 $content_user_data[$contentUserData->getSubContentId()][$contentUserData->getDataId()] = $contentUserData->getData();
             }
@@ -232,12 +234,12 @@ class H5PIntegration
         $corePath = "{$h5pAssetUrl}/h5p-core/";
         $editorPath = "{$h5pAssetUrl}/h5p-editor/";
         $css = array_merge(
-            $this->getAssets(\H5PCore::$styles, $corePath),
-            $this->getAssets(\H5PEditor::$styles, $editorPath)
+            $this->getAssets(H5PCore::$styles, $corePath),
+            $this->getAssets(H5peditor::$styles, $editorPath)
         );
         $js = array_merge(
-            $this->getAssets(\H5PCore::$scripts, $corePath),
-            $this->getAssets(\H5PEditor::$scripts, $editorPath, ['scripts/h5peditor-editor.js'])
+            $this->getAssets(H5PCore::$scripts, $corePath),
+            $this->getAssets(H5PEditor::$scripts, $editorPath, ['scripts/h5peditor-editor.js'])
         );
         $js[] = $this->getTranslationFilePath();
         return ['css' => $css, 'js' => $js];
@@ -304,5 +306,13 @@ class H5PIntegration
     public function getOptions()
     {
         return $this->options;
+    }
+
+    private function getUserId(UserInterface $user)
+    {
+        if (method_exists($user, 'getId')) {
+            return $user->getId();
+        }
+        return $user->getUserIdentifier();
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Studit\H5PBundle\DependencyInjection;
 
+use RuntimeException;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\NodeInterface;
@@ -19,12 +20,12 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('studit_h5_p');
 
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $rootNode = $treeBuilder->root('studit_h5_p');
+        $rootNode = $treeBuilder->getRootNode();
+
+        if (!method_exists($rootNode, 'children')) {
+            throw new RuntimeException('Your Symfony version does not support the children() method to define the root node in the H5P bundle configuration.');
         }
+
         $rootNode
             ->children()
             ->scalarNode('storage_dir')->defaultValue("h5p")->end()

--- a/Editor/EditorAjax.php
+++ b/Editor/EditorAjax.php
@@ -4,6 +4,8 @@ namespace Studit\H5PBundle\Editor;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Studit\H5PBundle\Entity\EventRepository;
+use Studit\H5PBundle\Entity\LibraryRepository;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class EditorAjax implements \H5PEditorAjaxInterface
@@ -35,7 +37,9 @@ class EditorAjax implements \H5PEditorAjaxInterface
      */
     public function getLatestLibraryVersions()
     {
-        return $this->manager->getRepository('Studit\H5PBundle\Entity\Library')->findLatestLibraryVersions();
+        /** @var LibraryRepository $repo */
+        $repo = $this->manager->getRepository('Studit\H5PBundle\Entity\Library');
+        return $repo->findLatestLibraryVersions();
     }
 
 
@@ -69,7 +73,9 @@ class EditorAjax implements \H5PEditorAjaxInterface
         $recentlyUsed = [];
         $user = $this->tokenStorage->getToken()->getUser();
         if (is_object($user)) {
-            $events = $this->manager->getRepository('Studit\H5PBundle\Entity\Event')->findRecentlyUsedLibraries($user->getId());
+            /** @var EventRepository $repo */
+            $repo = $this->manager->getRepository('Studit\H5PBundle\Entity\Event');
+            $events = $repo->findRecentlyUsedLibraries(method_exists($user, 'getId') ? $user->getId() : (method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : -1));
             foreach ($events as $event) {
                 $recentlyUsed[] = $event['libraryName'];
             }
@@ -96,5 +102,6 @@ class EditorAjax implements \H5PEditorAjaxInterface
      */
     public function getTranslations($libraries, $language_code)
     {
+        return [];
     }
 }

--- a/Editor/EditorStorage.php
+++ b/Editor/EditorStorage.php
@@ -5,10 +5,13 @@ namespace Studit\H5PBundle\Editor;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Exception\NotSupported;
 use H5peditorFile;
 use Studit\H5PBundle\Core\H5POptions;
 use Studit\H5PBundle\Core\H5PSymfony;
+use Studit\H5PBundle\Entity\LibrariesLanguagesRepository;
 use Studit\H5PBundle\Entity\Library;
+use Studit\H5PBundle\Entity\LibraryRepository;
 use Studit\H5PBundle\Event\H5PEvents;
 use Studit\H5PBundle\Event\LibraryFileEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -79,7 +82,9 @@ class EditorStorage implements \H5peditorStorage
      */
     public function getLanguage($machineName, $majorVersion, $minorVersion, $language)
     {
-        return $this->entityManager->getRepository('Studit\H5PBundle\Entity\LibrariesLanguages')->findForLibrary($machineName, $majorVersion, $minorVersion, $language);
+        /** @var LibrariesLanguagesRepository $repo */
+        $repo = $this->entityManager->getRepository('Studit\H5PBundle\Entity\LibrariesLanguages');
+        return $repo->findForLibrary($machineName, $majorVersion, $minorVersion, $language);
     }
 
     /**
@@ -92,12 +97,14 @@ class EditorStorage implements \H5peditorStorage
      * @param string $machineName The machine readable name of the library(content type)
      * @param int $majorVersion Major part of version number
      * @param int $minorVersion Minor part of version number
-     * @param string $language Language code default is EN
-     * @return string Translation in JSON format
+     * @return string[] Translation in JSON format
+     * @throws NotSupported
      */
     public function getAvailableLanguages($machineName, $majorVersion, $minorVersion)
     {
-        return $this->entityManager->getRepository('Studit\H5PBundle\Entity\LibrariesLanguages')->findForLibraryAllLanguages($machineName, $majorVersion, $minorVersion);
+        /** @var LibrariesLanguagesRepository $repo */
+        $repo = $this->entityManager->getRepository('Studit\H5PBundle\Entity\LibrariesLanguages');
+        return $repo->findForLibraryAllLanguages($machineName, $majorVersion, $minorVersion);
     }
 
     /**
@@ -131,7 +138,9 @@ class EditorStorage implements \H5peditorStorage
             return $this->getLibrariesWithDetails($libraries, $canCreateRestricted);
         }
         $libraries = [];
-        $librariesResult = $this->entityManager->getRepository('Studit\H5PBundle\Entity\Library')->findAllRunnableWithSemantics();
+        /** @var LibraryRepository $libraryRepo */
+        $libraryRepo = $this->entityManager->getRepository('Studit\H5PBundle\Entity\Library');
+        $librariesResult = $libraryRepo->findAllRunnableWithSemantics();
         foreach ($librariesResult as $library) {
             //Decode metadata setting
             $library->metadataSettings = json_decode($library->metadataSettings);
@@ -164,8 +173,10 @@ class EditorStorage implements \H5peditorStorage
     {
         $librariesWithDetails = [];
         foreach ($libraries as $library) {
+            /** @var LibraryRepository $repo */
+            $repo = $this->entityManager->getRepository('Studit\H5PBundle\Entity\Library');
             /** @var Library $details */
-            $details = $this->entityManager->getRepository('Studit\H5PBundle\Entity\Library')->findHasSemantics($library->name, $library->majorVersion, $library->minorVersion);
+            $details = $repo->findHasSemantics($library->name, $library->majorVersion, $library->minorVersion);
             if ($details) {
                 $library->tutorialUrl = $details->getTutorialUrl();
                 $library->title = $details->getTitle();

--- a/Editor/LibraryStorage.php
+++ b/Editor/LibraryStorage.php
@@ -7,6 +7,7 @@ namespace Studit\H5PBundle\Editor;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Studit\H5PBundle\Entity\Content;
+use Studit\H5PBundle\Entity\LibraryRepository;
 
 class LibraryStorage
 {
@@ -39,7 +40,9 @@ class LibraryStorage
     public function storeLibraryData($library, $parameters, Content $content = null)
     {
         $libraryData = Utilities::getLibraryProperties($library);
-        $libraryData['libraryId'] = $this->entityManager->getRepository('Studit\H5PBundle\Entity\Library')->findIdBy($libraryData['machineName'], $libraryData['majorVersion'], $libraryData['minorVersion']);
+        /** @var LibraryRepository $libraryRepo */
+        $libraryRepo = $this->entityManager->getRepository('Studit\H5PBundle\Entity\Library');
+        $libraryData['libraryId'] = $libraryRepo->findIdBy($libraryData['machineName'], $libraryData['majorVersion'], $libraryData['minorVersion']);
         if ($content) {
             $oldLibrary = [
                 'name' => $content->getLibrary()->getMachineName(),

--- a/Entity/LibraryRepository.php
+++ b/Entity/LibraryRepository.php
@@ -4,6 +4,7 @@
 namespace Studit\H5PBundle\Entity;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Statement;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\NoResultException;
 use Doctrine\Persistence\ManagerRegistry;
@@ -75,9 +76,10 @@ GROUP BY hl4.machine_name,
          hl4.has_icon
 EOT;
         $em = $this->getEntityManager();
+        /** @var Statement $stmt */
         $stmt = $em->getConnection()->prepare($sql);
-        $stmt->execute();
-        $libraryVersions = $stmt->fetchAll();
+        $result = $stmt->executeQuery();
+        $libraryVersions = $result->fetchAllAssociative();
         foreach ($libraryVersions as &$libraryVersion) {
             $libraryVersion = (object)$libraryVersion;
         }

--- a/Event/H5PEvents.php
+++ b/Event/H5PEvents.php
@@ -15,13 +15,13 @@ class H5PEvents extends \H5PEventBase
     const SEMANTICS = 'h5p.semantics';
 
     /**
-     * @var $userid int
+     * @var int $userid
     */
     private $userid;
 
     /**
-     * @var $em EntityManagerInterface
-    */
+     * @var EntityManagerInterface $em
+     */
     private $em;
     /**
      * H5PEvents constructor.
@@ -34,7 +34,7 @@ class H5PEvents extends \H5PEventBase
      * @param int $userId
      * @param EntityManagerInterface $em
      */
-    public function __construct($type, $sub_type = NULL, $content_id = NULL, $content_title = NULL, $library_name = NULL, $library_version = NULL, $userId= 0, EntityManagerInterface $em)
+    public function __construct(EntityManagerInterface $em, $type, $sub_type = NULL, $content_id = NULL, $content_title = NULL, $library_name = NULL, $library_version = NULL, $userId= 0)
     {
         parent::__construct($type, $sub_type, $content_id, $content_title, $library_name, $library_version);
         $this->userid = $userId;
@@ -69,7 +69,7 @@ class H5PEvents extends \H5PEventBase
     protected function saveStats()
     {
         $type = $this->type . ' ' . $this->sub_type;
-        /**
+        /*/**
          * @var Counters $current_num
         */
         /*$current_num = $this->em->getRepository("Studit\H5PBundle\Entity\Counters")->findOneBy(['type' => $type, 'libraryName' => $this->library_name, 'libraryVersion' => $this->library_version]);

--- a/README.MD
+++ b/README.MD
@@ -117,3 +117,11 @@ Changelog:
 - Fix bug with missing link img 
 - Fix Download package
 - Store usage data and points
+
+
+Developing:
+-------------
+Run the static analyzer like that:
+```sh
+php -d memory_limit=-1 vendor/bin/phpstan.phar analyze .
+```

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -86,6 +86,7 @@ services:
         tags:
             - { name: 'console.command', command: 'h5p-bundle:IncludeAssetsCommand' }
     Studit\H5PBundle\Command\H5pBundleCleanUpFilesCommand:
+        autowire: true
         tags:
             - { name: 'console.command', command: 'h5p-bundle:cleanup-files'}
 

--- a/composer.json
+++ b/composer.json
@@ -32,16 +32,20 @@
     "guzzlehttp/guzzle": "^7.5",
     "h5p/h5p-core": "^1.24",
     "h5p/h5p-editor": "^1.25",
-    "symfony/framework-bundle": "~4.0|~5.0|~6.0|~7.0",
-    "symfony/serializer": "~4.0|~5.0|~6.0",
+    "symfony/framework-bundle": "~5.0|~6.0|~7.0",
+    "symfony/serializer": "~5.0|~6.0|~7.0",
     "twig/extra-bundle": "^3.0",
     "doctrine/doctrine-bundle": "^2.0",
-    "symfony/security-bundle": "~4.0|~5.0|~6.0|~7.0",
-    "symfony/asset": "~4.0|~5.0|~6.0|~7.0"
+    "symfony/security-bundle": "~5.0|~6.0|~7.0",
+    "symfony/asset": "~5.0|~6.0|~7.0",
+    "symfony/form": "~5.0|~6.0|~7.0"
   },
   "autoload": {
     "psr-4": {
       "Studit\\H5PBundle\\": ""
     }
+  },
+  "require-dev": {
+    "phpstan/phpstan": "^1.10"
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+	excludePaths:
+		- vendor/*
+	level: 2
+	paths:
+		- .


### PR DESCRIPTION
Hey.

In [this PR](https://github.com/jorisdugue/h5p-bundle/pull/44) I fixed the symfony 6 compatibility, but actually just checked weather it compiles after `bin/console c:c`. 

With this PR I made it work with the method changes/deprecations etc.

Furthermore I added `phpstan` for static code analyses. 