### PR TITLE
feat(ci): remove deprecated stuff

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,13 @@ jobs:
         run: |
           VERSION=$(cat composer.json | jq -r '.version')
           echo "version=$VERSION" >> $GITHUB_ENV
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Check if tag exists
         id: check_tag
         run: |
           TAG_EXISTS=$(git tag -l "${{ steps.get_version.outputs.version }}")
           echo "tag_exists=$TAG_EXISTS" >> $GITHUB_ENV
-          echo "::set-output name=tag_exists::$TAG_EXISTS"
+          echo "tag_exists=$TAG_EXISTS" >> $GITHUB_OUTPUT
       - name: Create GitHub Tag
         if: steps.check_tag.outputs.tag_exists == ''
         uses: actions/github-script@v7


### PR DESCRIPTION
- Remove deprecated stuff about `set-output-commands` https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/